### PR TITLE
fix: error in hardhat deployed func, use new Hardhat deploy func

### DIFF
--- a/contract-deploy-demo/scripts/deploy.ts
+++ b/contract-deploy-demo/scripts/deploy.ts
@@ -7,10 +7,10 @@ async function main() {
 
   const lockedAmount = ethers.utils.parseEther("0.00000001");
 
-  const Lock = await ethers.getContractFactory("Lock");
-  const lock = await Lock.deploy(unlockTime, { value: lockedAmount });
-
-  await lock.deployed();
+  const lock = await ethers.deployContract("Lock", [unlockTime], {
+    value: lockedAmount,
+  });
+  await lock.waitForDeployment();
 
   console.log(`Lock with 0.00000001 ETH and unlock timestamp ${unlockTime} deployed to ${lock.address}`);
   console.log(`Block explorer URL: https://blockscout.scroll.io/address/${lock.address}`);

--- a/contract-deploy-demo/scripts/deploy.ts
+++ b/contract-deploy-demo/scripts/deploy.ts
@@ -12,8 +12,8 @@ async function main() {
   });
   await lock.waitForDeployment();
 
-  console.log(`Lock with 0.00000001 ETH and unlock timestamp ${unlockTime} deployed to ${lock.address}`);
-  console.log(`Block explorer URL: https://blockscout.scroll.io/address/${lock.address}`);
+  console.log(`Lock with 0.00000001 ETH and unlock timestamp ${unlockTime} deployed to ${lock.target}`);
+  console.log(`Block explorer URL: https://blockscout.scroll.io/address/${lock.target}`);
 }
 
 // We recommend this pattern to be able to use async/await everywhere


### PR DESCRIPTION
Description:
This Pull Request includes the following changes to use the new deploy features of Hardhat v2.0.0^:
- The ``deployContract()`` function is used instead of the old ``getContractFactory()`` and ``deploy()`` functions.
- ``getContractFactory()`` and ``deploy()`` functions are deprecated.
- ``address`` is deprecated, instead use ``target``.

In Hardhat v2.0.0^, a number of changes were made to the deploy process. So, the old code was not working, I updated it with the new version.

BTW the old code has a error:
![image](https://github.com/scroll-tech/scroll-guides/assets/72754835/10be538f-a002-438f-bbd9-1503485d1758)

If you need more information about Hardhat v2.0.0^ check this guides: https://hardhat.org/hardhat-runner/docs/guides/deploying